### PR TITLE
Removed 10s AQ files from sync

### DIFF
--- a/sync_data_from_googledrive.sh
+++ b/sync_data_from_googledrive.sh
@@ -4,7 +4,7 @@ cd ~/WACL/COZI_scrape
 
 # Downloads latest raw data
 rclone --config rclone.conf --include *.wlk -v --drive-shared-with-me sync CoziDrive:WACLroof raw_data/MET
-rclone --config rclone.conf --include logging* -v --drive-shared-with-me sync CoziDrive:COZI_DATA raw_data/AQ
+rclone --config rclone.conf --include logging_1min_* -v --drive-shared-with-me sync CoziDrive:COZI_DATA raw_data/AQ
 
 # Pre-processes it into a single CSV
 ~/.conda/envs/coziscrape/bin/python run_scrape.py clean_data/cozi_data.csv


### PR DESCRIPTION
AQ files with 10s frequency data are now uploaded to Google Drive.
These aren't needed by the app and so have been removed from the sync.