### PR TITLE
Corrected NO field name and removed unused Ozone

### DIFF
--- a/fields.json
+++ b/fields.json
@@ -1,8 +1,8 @@
 {
     "airquality": {
         "TheTime": "timestamp",
-		"thermo42C_42CTL60720328_NO": "NO (ppbV)",
-		"t500u_021732_NO2": "NO2 (ppbV)"
+        "thermo42C_42CTL60720328_NO": "NO (ppbV)",
+        "t500u_021732_NO2": "NO2 (ppbV)"
     },
     "meteorological": {
         "timestamp": "timestamp",

--- a/fields.json
+++ b/fields.json
@@ -1,8 +1,7 @@
 {
     "airquality": {
         "TheTime": "timestamp",
-        "O3_1": "O3 (ppbV)",
-		"thermo42c_42CTL60720328_NO": "NO (ppbV)",
+		"thermo42C_42CTL60720328_NO": "NO (ppbV)",
 		"t500u_021732_NO2": "NO2 (ppbV)"
     },
     "meteorological": {


### PR DESCRIPTION
The NO field wasn't case correct, and pandas requires all columns to be present otherwise it errors, so the Ozone has been removed.