### PR TITLE
Added CO2, CO, CH4 columns

### DIFF
--- a/fields.json
+++ b/fields.json
@@ -3,7 +3,10 @@
         "TheTime": "timestamp",
         "thermo49i_0536414593_O3": "O3 (ppbV)",
         "thermo42C_42CTL60720328_NO": "NO (ppbV)",
-        "t500u_021732_NO2": "NO2 (ppbV)"
+        "t500u_021732_NO2": "NO2 (ppbV)",
+        "CO2": "CO2 (ppmV)",
+        "al5002_0059_CONC": "CO (ppbV)",
+        "CH4": "CH4 (ppmV)"
     },
     "meteorological": {
         "timestamp": "timestamp",


### PR DESCRIPTION
These columns are present in the new CSV output from DAQ factory, even if they do not have data, so by including them in the scrape they will write NA values to the output CSV, so at least the Shiny and Grafana apps won't fail due to the columns not being present.